### PR TITLE
 Fix communications drop for large requests

### DIFF
--- a/src/main/java/com/beowulfe/hap/impl/connections/LengthPrefixedByteArrayProcessor.java
+++ b/src/main/java/com/beowulfe/hap/impl/connections/LengthPrefixedByteArrayProcessor.java
@@ -74,7 +74,7 @@ class LengthPrefixedByteArrayProcessor {
       results.add(buffer.toByteArray());
       buffer.reset();
       targetLength = 0;
-      if (pos + toWrite > data.length) {
+      if (pos + toWrite < data.length) {
         step(data, pos + toWrite, results);
       }
     } else {


### PR DESCRIPTION
if you have a lot of devices, the connection would drop whenever HomeKit would send a large request (something like "close all the shades in the house", or even just going to the Home tab where it queries that status of all accessories). turns out large requests were losing synchronization while decrypting, because we were dropping data in some cases.